### PR TITLE
Tracing for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ cd examples
 # Build a specific module (defaults to 'top' if unspecified)
 make MODULE_NAME=<name>
 
+# Build with tracing enabled
+# After simulation, you can find the waveform at logs/trace.vcd
+make MODULE_NAME=<name> TRACE_ON=1
+
 # Simulate the design
 make run MODULE_NAME=<name> TIMEOUT=1000
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,6 +1,11 @@
 MODULE_NAME ?= top
 TOP_MODULE ?= $(MODULE_NAME)
-VERILATOR_FLAGS ?= --top $(MODULE_NAME) -j 1 --trace --trace-structs
+
+ifdef TRACE_ON
+	VERILATOR_FLAGS ?= --top $(MODULE_NAME) -j 1 --trace --trace-structs
+else
+	VERILATOR_FLAGS ?= --top $(MODULE_NAME) -j 1
+endif
 
 TEST_DRIVER = sim_main.cpp
 

--- a/examples/sim_main.cpp
+++ b/examples/sim_main.cpp
@@ -11,8 +11,10 @@
 // Include common routines
 #include <verilated.h>
 
+#if VM_TRACE
 // Tracing
 #include <verilated_vcd_c.h>
+#endif
 
 // Include model header, generated from Verilating "top.v"
 #include "Vtop.h"
@@ -62,17 +64,21 @@ int main(int argc, char** argv) {
     // "TOP" will be the hierarchical name of the module.
     const std::unique_ptr<Vtop> top{new Vtop{contextp.get(), "TOP"}};
 
+#if VM_TRACE
     // Tracing
     std::unique_ptr<VerilatedVcdC> tfp{new VerilatedVcdC};
     top->trace(tfp.get(), 10);  // Trace 10 levels of hierarchy
     tfp->open("logs/trace.vcd");
+#endif
 
     top->clk_i = 0;
     top->rst_ni = !0;
 
     unsigned time_cnt = 0;
 
+#if VM_TRACE
     tfp->dump(contextp->time());
+#endif
 
     // Simulate until $finish
     while (!contextp->gotFinish() && time_cnt < timeout) {
@@ -105,14 +111,18 @@ int main(int argc, char** argv) {
         }
 
         top->eval();
+#if VM_TRACE
         tfp->dump(contextp->time());
+#endif
 
         ++ time_cnt;
     }
 
     // Final model cleanup
     top->final();
+#if VM_TRACE
     tfp->close();
+#endif
 
 
     // Final simulation summary


### PR DESCRIPTION
I've seen that traces are half-enabled in the examples testbench. Traces are helpful for understanding what's happening in terms of timing. Alternatively, this could be an option propagated through some flags. Feel free to edit/discard the PR depending on your plans.