### PR TITLE
fix `-stdin` codespan printouts

### DIFF
--- a/lib/compileHelpers.ml
+++ b/lib/compileHelpers.ml
@@ -18,15 +18,20 @@ let canonicalise_file_name file_origin file_name =
   else
     file_name
 
-let rec parse_recursive cunits parsed_files config filename =
+let rec parse_recursive cunits parsed_files (config : Config.compile_config) filename =
   if Utils.StringSet.mem filename !parsed_files |> not then (
     parsed_files := Utils.StringSet.add filename !parsed_files;
     let cunit =
+      let source_filename = match config.input_filenames with
+        | top_level::_ when (config.stdin && top_level = filename) -> "-"
+        | _ -> filename
+      in
       try
-        In_channel.with_open_bin
+        InChannelCacheableAliasable.with_open_aliased
+          source_filename
           filename
-          (fun in_channel ->
-            let lexbuf = Lexing.from_channel in_channel in
+          (fun in_data ->
+            let lexbuf = Lexing.from_string (Bytes.to_string (in_data.buffer)) in
             try Parser.cunit Lexer.read lexbuf
             with
               | Lexer.SyntaxError msg ->
@@ -62,3 +67,4 @@ let rec parse_recursive cunits parsed_files config filename =
           |> parse_recursive cunits parsed_files config
     ) cunit.imports
   )
+


### PR DESCRIPTION
Changes to compileDriver.ml in merge:

b03616fcb9d674e8ab94cb19f46e299990c6d998

were supposed to be merged into compileHelpers.ml here:

81d837b3e8d10f097f0255583a34a6ce418b7841

but were auto-deleted as the original function was refactored here:

73fe506bf59711bf9e8e782c1637f6a9c7ea3efe

This corrects the merge, and thus fixes file data caching during compilation file read (and thus standard input codespan printouts)