### PR TITLE
Fix inconsistent error message formatting

### DIFF
--- a/lib/lifetimeCheck.ml
+++ b/lib/lifetimeCheck.ml
@@ -2,7 +2,8 @@ open Lang
 open EventGraph
 open GraphAnalysis
 
-let string_of_lt (lt : lifetime) : string =
+(* Lifetime formatted string for debugging *)
+let _string_of_lt (lt : lifetime) : string =
   String.concat "" (List.map (fun s ->
       Printf.sprintf "%d |> %s | " (fst s).id (string_of_delay_pat (snd s))
     ) lt.dead)
@@ -326,9 +327,8 @@ let lifetime_check (config : Config.compile_config) (ci : cunit_info) (g : event
       | [] -> ()
     );
     if lifetime_in_range g.events lookup_message lt td.lt |> not then
-      let err_msg = Printf.sprintf "Value does not live long enough in message send! (dies @ %s)" (string_of_lt lt) in
       raise (LifetimeCheckError [
-        Text err_msg;
+        Text "Value does not live long enough in send!";
         Except.codespan_local span
       ])
   in
@@ -370,7 +370,7 @@ let lifetime_check (config : Config.compile_config) (ci : cunit_info) (g : event
           if lifetime_in_range g.events lookup_message (EventGraphOps.lifetime_immediate ev) td.lt |> not then
             raise (LifetimeCheckError
               [
-                Text (Printf.sprintf "Value does not live long enough in debug print! [Event Id = %d] : %s" ev.id (string_of_lt td.lt));
+                Text "Value does not live long enough in debug print!";
                 Except.codespan_local a.span
               ])
           else ()
@@ -542,7 +542,8 @@ let lifetime_check (config : Config.compile_config) (ci : cunit_info) (g : event
         ) g.events;
         let min_weights = GraphAnalysis.event_min_among_succ g.events slacks in
         if min_weights.(ev_root.id) > init_offset && not is_one_cycle_static_1_1 then
-          let error_msg = Printf.sprintf "Static sync mode mismatch (actual init offset = %d > expected init offset %d)!"
+          let error_msg = Printf.sprintf "Static sync mode mismatch for initial offset of %s (actual init offset = %d > expected init offset %d)!"
+            relative_msg
             min_weights.(ev_root.id) init_offset
           in
           raise (LifetimeCheckError [Text error_msg]) (* TODO: better error message *)
@@ -593,7 +594,8 @@ let lifetime_check (config : Config.compile_config) (ci : cunit_info) (g : event
             let maxv = GraphAnalysis.event_predecessors ev |> List.map (fun ev' -> slacks.(ev'.id))
               |> List.fold_left Int.max (-event_distance_max) in
             if maxv > -gap then
-              let error_msg = Printf.sprintf "Static sync mode mismatch (actual gap = %d < expected gap %d)!"
+              let error_msg = Printf.sprintf "Static sync mode mismatch between %s and %s (actual gap = %d < expected gap %d)!"
+                relative_msg msg
                 (-maxv) gap
               in
               raise (LifetimeCheckError [Text error_msg; Except.codespan_local sa.span])


### PR DESCRIPTION
Replicates formatting for displaying the relevant endpoints for all static sync mismatch errors

Also removes not-very-useful output for not-live-long-enough errors. Specifically, existing ones implies the end of lifetime at a certain event, but

1. an event id is not useful to the end user,
2. the event id does not actually correspond to its exact "time-of-death"